### PR TITLE
Specify CUDA flavor as devel to include nvcc at runtime

### DIFF
--- a/runway.yml
+++ b/runway.yml
@@ -1,6 +1,7 @@
 entrypoint: python runway_model.py
 python: 3.6
 cuda: 10.0
+cuda_flavor: devel
 spec:
   gpu: True
   cpu: False


### PR DESCRIPTION
Brannon from Runway here 👋 

I noticed your model was failing with the runtime error `nvcc: not found`. This looks to me like the Development version of the CUDA Docker image is required. A few weeks ago we added the ability to specify the CUDA flavor of the base Docker image with the `cuda_flavor` property in the `runway.yml` file.

It accepts the following values: `base`, `runtime` (default), `devel`.

Cheers and hope this helps!